### PR TITLE
Updates to CampaignController

### DIFF
--- a/app/config/local/database.php
+++ b/app/config/local/database.php
@@ -44,11 +44,11 @@ return array(
 
     'mongodb' => array(
       'driver'   => 'mongodb',
-      'host'     => getenv(['DB_HOST']) ? getenv(['DB_HOST']) : 'localhost',
-      'port'     => getenv(['DB_PORT']) ? getenv(['DB_PORT']) : 27017,
-      'username' => getenv(['DB_USERNAME']) ? getenv(['DB_USERNAME']) : '',
-      'password' => getenv(['DB_PASSWORD']) ? getenv(['DB_PASSWORD']) : '',
-      'database' => getenv(['DB_NAME']) ? getenv(['DB_NAME']) : 'userapi',
+      'host'     => getenv('DB_HOST') ? getenv('DB_HOST') : 'localhost',
+      'port'     => getenv('DB_PORT') ? getenv('DB_PORT') : 27017,
+      'username' => getenv('DB_USERNAME') ? getenv('DB_USERNAME') : '',
+      'password' => getenv('DB_PASSWORD') ? getenv('DB_PASSWORD') : '',
+      'database' => getenv('DB_NAME') ? getenv('DB_NAME') : 'userapi',
     ),
 
   ),

--- a/app/controllers/CampaignController.php
+++ b/app/controllers/CampaignController.php
@@ -76,7 +76,7 @@ class CampaignController extends \BaseController {
     $campaign->sid = $sid;
     $campaign = $user->campaigns()->save($campaign);
     $response = array(
-      'created_at' => $campaign->created_at->format('Y-m-d H:i:s'),
+      CAMPAIGN_RESPONSE::created_at => $campaign->created_at,
       SIGNUP_ATTRIBUTE::sid => $campaign->sid
     );
 
@@ -123,7 +123,7 @@ class CampaignController extends \BaseController {
       $campaign = $user->campaigns()->save($campaign);
 
       $response = array(
-        'created_at' => $campaign->created_at->format('Y-m-d H:i:s'),
+        CAMPAIGN_RESPONSE::created_at => $campaign->created_at,
       );
 
       $statusCode = 201;
@@ -146,7 +146,7 @@ class CampaignController extends \BaseController {
       $campaign = $user->campaigns()->save($campaign);
 
       $response = array(
-        'updated_at' => $campaign->updated_at->format('Y-m-d H:i:s'),
+        CAMPAIGN_RESPONSE::updated_at => $campaign->updated_at,
       );
     }
 
@@ -196,11 +196,19 @@ class CampaignController extends \BaseController {
     $campaign = $user->campaigns()->save($campaign);
 
     $response = array(
-      'updated_at' => $campaign->updated_at->format('Y-m-d H:i:s'),
+      CAMPAIGN_RESPONSE::updated_at => $campaign->updated_at,
       REPORTBACK_ATTRIBUTE::rbid => $campaign->rbid
     );
 
     return Response::json($response, 200);
   }
 
+}
+
+/**
+ * Abstract class defining string values for response properties.
+ */
+abstract class CAMPAIGN_RESPONSE {
+  const created_at = 'created_at';
+  const updated_at = 'updated_at';
 }

--- a/app/controllers/CampaignController.php
+++ b/app/controllers/CampaignController.php
@@ -116,10 +116,10 @@ class CampaignController extends \BaseController {
     if (!($campaign instanceof Campaign)) {
       $campaign = new Campaign;
       $campaign->nid = $nid;
-      $campaign->rbid = $rbid;
-      $campaign->quantity = Input::get('quantity');
-      $campaign->why_participated = Input::get('why_participated');
-      $campaign->file_url = Input::get('file_url');
+
+      // Only input non-null values
+      $input = array_filter($input, function($val) { return !is_null($val); });
+      $campaign->fill($input);
       $campaign = $user->campaigns()->save($campaign);
 
       $response = array(
@@ -129,11 +129,9 @@ class CampaignController extends \BaseController {
       $statusCode = 201;
     }
     else {
-      $campaign->rbid = $rbid;
-
+      // Only input non-null values
       $input = array_filter($input, function($val) { return !is_null($val); });
       $campaign->fill($input);
-
       $campaign = $user->campaigns()->save($campaign);
 
       $response = array(

--- a/app/controllers/CampaignController.php
+++ b/app/controllers/CampaignController.php
@@ -131,17 +131,8 @@ class CampaignController extends \BaseController {
     else {
       $campaign->rbid = $rbid;
 
-      if (!is_null(Input::get(REPORTBACK_ATTRIBUTE::quantity))) {
-        $campaign->quantity = Input::get(REPORTBACK_ATTRIBUTE::quantity);
-      }
-
-      if (!is_null(Input::get(REPORTBACK_ATTRIBUTE::why_participated))) {
-        $campaign->why_participated = Input::get(REPORTBACK_ATTRIBUTE::why_participated);
-      }
-
-      if (!is_null(Input::get(REPORTBACK_ATTRIBUTE::file_url))) {
-        $campaign->file_url = Input::get(REPORTBACK_ATTRIBUTE::file_url);
-      }
+      $input = array_filter($input, function($val) { return !is_null($val); });
+      $campaign->fill($input);
 
       $campaign = $user->campaigns()->save($campaign);
 
@@ -175,23 +166,18 @@ class CampaignController extends \BaseController {
 
     $token = Request::header('Session');
     $user = Token::userFor($token);
-    $campaign = $user->campaigns()->where(REPORTBACK_ATTRIBUTE::rbid, '=', $rbid)->first();
+    $campaign = $user->campaigns()
+      ->where('nid', '=', $nid)
+      ->where(REPORTBACK_ATTRIBUTE::rbid, '=', $rbid)
+      ->first();
 
     if (!($campaign instanceof Campaign)) {
       return Response::json("Campaign does not exist", 401);
     }
 
-    if (!is_null(Input::get(REPORTBACK_ATTRIBUTE::quantity))) {
-      $campaign->quantity = Input::get(REPORTBACK_ATTRIBUTE::quantity);
-    }
-
-    if (!is_null(Input::get(REPORTBACK_ATTRIBUTE::why_participated))) {
-      $campaign->why_participated = Input::get(REPORTBACK_ATTRIBUTE::why_participated);
-    }
-
-    if (!is_null(Input::get(REPORTBACK_ATTRIBUTE::file_url))) {
-      $campaign->file_url = Input::get(REPORTBACK_ATTRIBUTE::file_url);
-    }
+    $input = Input::only(REPORTBACK_ATTRIBUTE::editableKeys());
+    $input = array_filter($input, function($val) { return !is_null($val); });
+    $campaign->fill($input);
 
     $campaign = $user->campaigns()->save($campaign);
 

--- a/app/controllers/UserController.php
+++ b/app/controllers/UserController.php
@@ -61,7 +61,7 @@ class UserController extends \BaseController {
         $user->save();
 
         $response = array(
-          RESPONSE_PARAMS::created_at => $user->created_at,
+          USER_RESPONSE::created_at => $user->created_at,
           USER_PARAMS::_id => $user->_id
         );
 
@@ -101,7 +101,7 @@ class UserController extends \BaseController {
 
       $user->save();
 
-      $response = array(RESPONSE_PARAMS::updated_at => $user->updated_at);
+      $response = array(USER_RESPONSE::updated_at => $user->updated_at);
 
       return Response::json($response, 202);
     }
@@ -154,10 +154,10 @@ class UserController extends \BaseController {
         $response = array(
           USER_PARAMS::email => $user->email,
           USER_PARAMS::mobile => $user->mobile,
-          RESPONSE_PARAMS::created_at => $user->created_at,
-          RESPONSE_PARAMS::updated_at => $user->updated_at,
+          USER_RESPONSE::created_at => $user->created_at,
+          USER_RESPONSE::updated_at => $user->updated_at,
           USER_PARAMS::_id => $user->_id,
-          RESPONSE_PARAMS::session_token => $token->key
+          USER_RESPONSE::session_token => $token->key
         );
         return Response::json($response, '200');
       }
@@ -241,7 +241,10 @@ abstract class USER_PARAMS {
   }
 };
 
-abstract class RESPONSE_PARAMS {
+/**
+ * Abstract class defining string values for response properties.
+ */
+abstract class USER_RESPONSE {
   const session_token = 'session_token';
   const created_at = 'created_at';
   const updated_at = 'updated_at';

--- a/app/database/seeds/DatabaseSeeder.php
+++ b/app/database/seeds/DatabaseSeeder.php
@@ -42,7 +42,15 @@ class UserTableSeeder extends Seeder {
       'country' => 'US',
       'birthdate' => '12/17/91',
       'first_name' => 'First',
-      'last_name' => 'Last'
+      'last_name' => 'Last',
+      'campaigns' => array(
+        array(
+          'nid' => 100,
+          'rbid' => 10,
+          'quantity' => 100,
+          '_id' => '5480c950bffebc651c8b456e'
+        )
+      )
     )); 
 
     User::create(array(

--- a/app/models/Campaign.php
+++ b/app/models/Campaign.php
@@ -11,7 +11,7 @@ class Campaign extends Eloquent {
    *
    * @var array
    */
-  protected $hidden = array('_id', 'created_at', 'updated_at');
+  protected $hidden = array('_id');
 
   /**
    * Validation rules
@@ -74,12 +74,7 @@ class Campaign extends Eloquent {
    */
   private function formatDate($value) {
     $date = $this->asDateTime($value);
-    if ($value instanceof MongoDate) {
-      return $date->format('Y-m-d H:i:s');
-    }
-    else {
-      return $date;
-    }
+    return $date->format('Y-m-d H:i:s');
   }
 
   /**

--- a/app/models/Campaign.php
+++ b/app/models/Campaign.php
@@ -66,6 +66,36 @@ class Campaign extends Eloquent {
     return $this->validationMessages;
   }
 
+  /**
+   * Formats date if its a MongoDate.
+   *
+   * @param $value date attribute value
+   * @return String
+   */
+  private function formatDate($value) {
+    $date = $this->asDateTime($value);
+    if ($value instanceof MongoDate) {
+      return $date->format('Y-m-d H:i:s');
+    }
+    else {
+      return $date;
+    }
+  }
+
+  /**
+   * Accessor for created_at date. Formats to Y-m-d H:i:s.
+   */
+  public function getCreatedAtAttribute($value) {
+    return $this->formatDate($value);
+  }
+
+  /**
+   * Accessor for updated_at date. Formats to Y-m-d H:i:s.
+   */
+  public function getUpdatedAtAttribute($value) {
+    return $this->formatDate($value);
+  }
+
   public function getQuantityAttribute($value) {
     return (int) $value;
   }
@@ -112,5 +142,3 @@ abstract class REPORTBACK_ATTRIBUTE {
 abstract class SIGNUP_ATTRIBUTE {
   const sid = 'sid';
 }
-
-

--- a/app/models/Campaign.php
+++ b/app/models/Campaign.php
@@ -132,6 +132,7 @@ abstract class REPORTBACK_ATTRIBUTE {
   public static function editableKeys()
   {
     return array(
+      REPORTBACK_ATTRIBUTE::rbid,
       REPORTBACK_ATTRIBUTE::file_url,
       REPORTBACK_ATTRIBUTE::quantity,
       REPORTBACK_ATTRIBUTE::why_participated

--- a/app/models/Campaign.php
+++ b/app/models/Campaign.php
@@ -7,6 +7,11 @@ class Campaign extends Eloquent {
   protected $primaryKey = "_id";
 
   /**
+   * Guarded attributes
+   */
+  protected $guarded = array('_id');
+
+  /**
    * The attributes excluded from the model's JSON form.
    *
    * @var array

--- a/app/models/Campaign.php
+++ b/app/models/Campaign.php
@@ -10,16 +10,107 @@ class Campaign extends Eloquent {
    * The attributes excluded from the model's JSON form.
    *
    * @var array
-  */
+   */
   protected $hidden = array('_id', 'created_at', 'updated_at');
 
-  /*
+  /**
+   * Validation rules
+   */
+  private $rules = array(
+    REPORTBACK_ATTRIBUTE::rbid => 'integer',
+    REPORTBACK_ATTRIBUTE::file_url => 'url',
+    REPORTBACK_ATTRIBUTE::quantity => 'integer',
+
+    SIGNUP_ATTRIBUTE::sid => 'integer',
+  );
+
+  /**
+   * Messages returned from a failed validation.
+   */
+  private $validationMessages;
+
+  /**
    * Automatically convert date columns to instances of Carbon
    *
-  */
+   */
   public function getDates()
   {
     return array('created_at', 'updated_at');
   }
 
+  /**
+   * Validate input based on this model's rules.
+   *
+   * @param $data
+   * @return bool
+   */
+  public function validate($data)
+  {
+    $v = Validator::make($data, $this->rules);
+
+    if ($v->fails()) {
+      $this->validationMessages = $v->messages()->all();
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Get validation messages.
+   *
+   * @return array
+   */
+  public function getValidationMessages()
+  {
+    return $this->validationMessages;
+  }
+
+  public function getQuantityAttribute($value) {
+    return (int) $value;
+  }
+
+  public function setQuantityAttribute($value) {
+    $this->attributes[REPORTBACK_ATTRIBUTE::quantity] = (int) $value;
+  }
+
+  public function getRbidAttribute($value) {
+    return (int) $value;
+  }
+
+  public function setRbidAttribute($value) {
+    $this->attributes[REPORTBACK_ATTRIBUTE::rbid] = (int) $value;
+  }
+
+  public function getSidAttribute($value) {
+    return (int) $value;
+  }
+
+  public function setSidAttribute($value) {
+    $this->attributes[SIGNUP_ATTRIBUTE::sid] = (int) $value;
+  }
+
 }
+
+abstract class REPORTBACK_ATTRIBUTE {
+  const rbid = 'rbid';
+
+  const file_url = 'file_url';
+  const quantity = 'quantity';
+  const why_participated = 'why_participated';
+
+  public static function editableKeys()
+  {
+    return array(
+      REPORTBACK_ATTRIBUTE::file_url,
+      REPORTBACK_ATTRIBUTE::quantity,
+      REPORTBACK_ATTRIBUTE::why_participated
+    );
+  }
+}
+
+abstract class SIGNUP_ATTRIBUTE {
+  const sid = 'sid';
+}
+
+

--- a/app/models/User.php
+++ b/app/models/User.php
@@ -93,12 +93,7 @@ class User extends Eloquent implements UserInterface, RemindableInterface {
    */
   private function formatDate($value) {
     $date = $this->asDateTime($value);
-    if ($value instanceof MongoDate) {
-      return $date->format('Y-m-d H:i:s');
-    }
-    else {
-      return $date;
-    }
+    return $date->format('Y-m-d H:i:s');
   }
 
   /**

--- a/app/tests/CampaignTest.php
+++ b/app/tests/CampaignTest.php
@@ -6,7 +6,7 @@ class CampaignTest extends TestCase {
    * Migrate database and set up HTTP headers
    *
    * @return void
-  */
+   */
   public function setUp()
   {
     parent::setUp();
@@ -29,7 +29,7 @@ class CampaignTest extends TestCase {
    * GET /users/campaigns
    *
    * @return void
-  */
+   */
   public function testGetCampaignsFromUser()
   {   
     $parameters = array('email' => 'test@dosomething.org',);
@@ -49,7 +49,7 @@ class CampaignTest extends TestCase {
    * POST /campaigns/:nid/signup
    *
    * @return void
-  */
+   */
   public function testSubmitCampaignSignup()
   {   
     // Campaign sid
@@ -71,22 +71,22 @@ class CampaignTest extends TestCase {
   }
 
   /**
-   * Test for submiting a campaign reportback
+   * Test for submiting a campaign report back.
    * POST /campaigns/:nid/reportback
    *
    * @return void
-  */
+   */
   public function testSubmitCampaignReportback()
   {   
     // Campaign reportback data
-    $rbid = array(
-      'rbid' => '235',
-      'quantity' => '3',
-      'why_participated' => "I love helping others",
-      'file_url' => 'happy.jpg'
+    $rb = array(
+      'rbid' => 100,
+      'quantity' => 10,
+      'why_participated' => 'I love helping others',
+      'file_url' => 'http://example.test/example.png'
     );
 
-    $response = $this->call('POST', '1/campaigns/123/reportback', array(), array(), $this->server, json_encode($rbid));
+    $response = $this->call('POST', '1/campaigns/123/reportback', array(), array(), $this->server, json_encode($rb));
     $content = $response->getContent();
     $data = json_decode($content, true);
 
@@ -101,4 +101,47 @@ class CampaignTest extends TestCase {
     $this->assertArrayHasKey('rbid', $data);
   }
 
+  /**
+   * Test for successful update of a campaign report back.
+   * PUT /campaigns/:nid/reportback
+   *
+   * @return void
+   */
+  public function testUpdateCampaignReportback200() {
+    $rb = array(
+      'rbid' => 10,
+      'quantity' => '1'
+    );
+
+    $response = $this->call('PUT', '1/campaigns/100/reportback', array(), array(), $this->server, json_encode($rb));
+    $content = $response->getContent();
+
+    // Response should return a 200
+    $this->assertEquals(200, $response->getStatusCode());
+
+    // Response should be valid JSON
+    $this->assertJson($content);
+  }
+
+  /**
+   * Test for update of a non-existent campaign report back.
+   * PUT /campaigns/:nid/reportback
+   *
+   * @return void
+   */
+  public function testUpdateCampaignReportback401() {
+    $rb = array(
+      'rbid' => 11,
+      'quantity' => '1'
+    );
+
+    $response = $this->call('PUT', '1/campaigns/100/reportback', array(), array(), $this->server, json_encode($rb));
+    $content = $response->getContent();
+
+    // Response should return a 401
+    $this->assertEquals(401, $response->getStatusCode());
+
+    // Response should be valid JSON
+    $this->assertJson($content);
+  }
 }


### PR DESCRIPTION
#### What's this PR do?
Modifies PUT requests for Campaigns. Like the User model, it no longer requires the full resource to be included in the request.

Also doing some additional validating and formatting like rbid, sid to ints and dates being formatted to `Y-m-d H:i:s`.

#### Where should the reviewer start?
###### CampaignController::updateReportback()
Changes here make it so that only non-null values would get updated on the resource.

###### CampaignController::reportback()
Has similar logic, but additionally creates a campaign entry in the user's document if one doesn't yet exist. The changes here also add some more validation and error handling than before.

###### Campaign.php
Removes the timestamps from the hidden property so that they can be returned in queries. Rules added to enforce sid, rbid, and quantity as integers, and file_url as a url. And then timestamp accessors that format the dates (which in this case can be MongoDate objects) to `Y-m-d H:i:s`.

#### How should this be manually tested?
Unit tests: `$ vender/bin/phpunit`

You can also submit queries using this Postman collection: https://gist.github.com/jonuy/5ef93fa434db6ce87ba7
The relevant ones here are Submit Sign Up, Submit Report Back, Update Report Back, and Get User's Campaign Data.

#### What are the relevant tickets?
Closes #15 
Closes #17 
Closes #18 

Fixes the PUT part of #16